### PR TITLE
Add persistent logging with retention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .git
 venv
 .env
+logs/


### PR DESCRIPTION
## Summary
- add a logging setup that writes to rotating log files and keeps only the last five days
- route script log helpers through the logging module so the summary is captured too
- ignore the log directory in git

## Testing
- python3 -m py_compile kea_ipam_sync.py

------
https://chatgpt.com/codex/tasks/task_e_68c99d8f5110832799a0b01d70700656