### PR TITLE
Add SSH download support for JSON sync workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,9 @@ KEA_DB_USER=kea
 KEA_DB_PASS=
 
 # --- Geração de arquivo JSON (json_kea_ipam_sync.py) ---------------------------
-KEA_JSON_OUTPUT_PATH=/usr/local/etc/kea/kea-dhcp4.conf
+# Caminho local (opcional) para salvar o arquivo durante a sincronização.
+# O padrão mantém o arquivo na mesma pasta do script.
+KEA_JSON_OUTPUT_PATH=kea-dhcp4.conf
 # Opcional: usar um template base existente
 # KEA_JSON_TEMPLATE_PATH=/usr/local/etc/kea/kea-dhcp4.template
 
@@ -55,6 +57,8 @@ PF_SSH_REMOTE_PATH=/usr/local/etc/kea/kea-dhcp4.conf
 # PF_SSH_STRICT_HOST_KEY_CHECKING=true
 # Argumentos adicionais para ssh/scp (ex.: jump host)
 # PF_SSH_EXTRA_ARGS=-o ProxyCommand="ssh jumphost -W %h:%p"
+# Remove o arquivo local temporário após o deploy bem-sucedido
+PF_SSH_REMOVE_LOCAL_COPY=false
 
 # Controla se o script executará um reload após atualizar as reservas
 RELOAD_AFTER_DB=true


### PR DESCRIPTION
## Summary
- fetch the remote kea-dhcp4.conf via SSH before processing and upload the updated file back
- allow optionally removing the local temporary copy after a successful deployment
- document the new workflow and configuration variables in the README and .env example

## Testing
- python -m py_compile json_kea_ipam_sync.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914da6cbe8c832787908f0461e764ae)