### PR TITLE
Sync phpIPAM static maps to pfSense DHCP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,7 +65,8 @@ RELOAD_AFTER_DB=true
 
 # --- pfSense ($config) --------------------------------------------------------
 # Caminho do array $config que armazena a configuração DHCP.
-# O modo pfSense sempre força "dhcpd" (qualquer outro valor será ignorado).
+# As reservas são gravadas diretamente em $config['dhcpd'][iface]['staticmap']
+# e qualquer caminho diferente será ignorado.
 PF_CONFIG_PATH=dhcpd
 # Mensagem registrada no config.xml ao aplicar alterações
 PF_CONFIG_WRITE_NOTE=Atualizado via Kea_IPAM_Sync

--- a/.env.example
+++ b/.env.example
@@ -64,13 +64,16 @@ PF_SSH_REMOVE_LOCAL_COPY=false
 RELOAD_AFTER_DB=true
 
 # --- pfSense ($config) --------------------------------------------------------
-# Caminho do array $config que armazena o Dhcp4 (separado por dois pontos)
-PF_CONFIG_PATH=installedpackages:kea_dhcp4:config:0:Dhcp4
+# Caminho do array $config que armazena a configuração DHCP (separado por dois pontos)
+# Para o DHCP nativo o padrão é "dhcpd"; ajuste apenas se tiver uma árvore customizada
+PF_CONFIG_PATH=dhcpd
 # Mensagem registrada no config.xml ao aplicar alterações
 PF_CONFIG_WRITE_NOTE=Atualizado via Kea_IPAM_Sync
 
 # --- Mapas de subnet-id -------------------------------------------------------
 # Exemplo de mapeamento: subnetId do phpIPAM -> subnet-id do Kea
+# (no modo pfSense, apenas as chaves são usadas para listar as sub-redes sincronizadas
+# e o script descobre automaticamente a interface correspondente no $config)
 SUBNET_ID_MAP_JSON={"39":188}
 # Alternativa em formato separado por dois pontos (pode listar vários separados por vírgula)
 # IPAM_SUBNETID_TO_ID=39:188,40:189

--- a/.env.example
+++ b/.env.example
@@ -64,8 +64,8 @@ PF_SSH_REMOVE_LOCAL_COPY=false
 RELOAD_AFTER_DB=true
 
 # --- pfSense ($config) --------------------------------------------------------
-# Caminho do array $config que armazena a configuração DHCP (separado por dois pontos)
-# Para o DHCP nativo o padrão é "dhcpd"; ajuste apenas se tiver uma árvore customizada
+# Caminho do array $config que armazena a configuração DHCP.
+# O modo pfSense sempre força "dhcpd" (qualquer outro valor será ignorado).
 PF_CONFIG_PATH=dhcpd
 # Mensagem registrada no config.xml ao aplicar alterações
 PF_CONFIG_WRITE_NOTE=Atualizado via Kea_IPAM_Sync

--- a/README.md
+++ b/README.md
@@ -121,10 +121,12 @@ PF_SSH_REMOVE_LOCAL_COPY=false
 RELOAD_AFTER_DB=true
 
 # --- pfSense ($config) ---
-PF_CONFIG_PATH=installedpackages:kea_dhcp4:config:0:Dhcp4
+# Use "dhcpd" para o serviço nativo ou um caminho customizado separado por dois pontos
+PF_CONFIG_PATH=dhcpd
 PF_CONFIG_WRITE_NOTE=Atualizado via Kea_IPAM_Sync
 
 # --- Mapeamentos de subnet-id ---
+# (as chaves definem as sub-redes buscadas; no modo pfSense a interface é descoberta automaticamente)
 SUBNET_ID_MAP_JSON={"39":188}
 
 # --- (Opcional) Control Agent ---
@@ -173,7 +175,9 @@ Quando `PF_SSH_PASSWORD` estiver definido, o script usa `sshpass` (se disponíve
 O `pfsense_kea_ipam_sync.py` reutiliza exatamente essas mesmas variáveis para executar comandos PHP diretamente no firewall. Caso nenhum `PF_SSH_HOST` seja informado, o script supõe que está rodando dentro do próprio pfSense (onde o binário `php` já está presente).
 
 #### Escolhendo o nó no `$config`
-Defina `PF_CONFIG_PATH` para apontar o caminho até a estrutura que representa o `Dhcp4` (por exemplo `installedpackages:kea_dhcp4:config:0:Dhcp4`). Use dois pontos (`:`) para separar cada nível do array `$config`. O script lê esse nó antes de aplicar qualquer alteração, compara com o que veio do phpIPAM e só executa `write_config()` + `services_kea_*_configure()` quando detectar um `update`. Se nada mudar, apenas um log é emitido e o reload é pulado.
+Defina `PF_CONFIG_PATH` para apontar o caminho até a estrutura que representa o DHCP. Para o serviço nativo, basta usar `dhcpd` (padrão). Se estiver usando outra árvore, mantenha o formato `nivel1:nivel2:...`. O script lê esse nó antes de aplicar qualquer alteração, compara com o que veio do phpIPAM e só executa `write_config()` + o reload do serviço DHCP quando detectar um `update`. Se nada mudar, apenas um log é emitido e o reload é pulado.
+
+O `pfsense_kea_ipam_sync.py` também aproveita as chaves configuradas em `SUBNET_ID_MAP_JSON` (ou equivalentes) para buscar as sub-redes no phpIPAM e cruza cada IP com os dados de `$config['interfaces']`. Dessa forma ele descobre automaticamente qual interface DHCP deve receber as reservas, eliminando a necessidade de mapear `lan`, `vlanX` etc. manualmente.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ PF_SSH_REMOVE_LOCAL_COPY=false
 RELOAD_AFTER_DB=true
 
 # --- pfSense ($config) ---
-# Use "dhcpd" para o serviço nativo ou um caminho customizado separado por dois pontos
+# O modo pfSense sempre trabalha com $config['dhcpd'] (qualquer outro valor será ignorado)
 PF_CONFIG_PATH=dhcpd
 PF_CONFIG_WRITE_NOTE=Atualizado via Kea_IPAM_Sync
 
@@ -175,7 +175,9 @@ Quando `PF_SSH_PASSWORD` estiver definido, o script usa `sshpass` (se disponíve
 O `pfsense_kea_ipam_sync.py` reutiliza exatamente essas mesmas variáveis para executar comandos PHP diretamente no firewall. Caso nenhum `PF_SSH_HOST` seja informado, o script supõe que está rodando dentro do próprio pfSense (onde o binário `php` já está presente).
 
 #### Escolhendo o nó no `$config`
-Defina `PF_CONFIG_PATH` para apontar o caminho até a estrutura que representa o DHCP. Para o serviço nativo, basta usar `dhcpd` (padrão). Se estiver usando outra árvore, mantenha o formato `nivel1:nivel2:...`. O script lê esse nó antes de aplicar qualquer alteração, compara com o que veio do phpIPAM e só executa `write_config()` + o reload do serviço DHCP quando detectar um `update`. Se nada mudar, apenas um log é emitido e o reload é pulado.
+O modo pfSense trabalha exclusivamente com `$config['dhcpd']`. Mesmo que `PF_CONFIG_PATH` seja definido com outro caminho (por exemplo, o antigo `installedpackages:kea_dhcp4:...`), o script irá ignorar o valor e usar `dhcpd` automaticamente. Isso evita que as reservas sejam gravadas em árvores que não são consumidas pelo serviço DHCP nativo. Se você migrou de uma versão anterior, basta remover o valor antigo do `.env` ou deixá-lo como `dhcpd`.
+
+O script lê esse nó antes de aplicar qualquer alteração, compara com o que veio do phpIPAM e só executa `write_config()` + o reload do serviço DHCP quando detectar um `update`. Se nada mudar, apenas um log é emitido e o reload é pulado.
 
 O `pfsense_kea_ipam_sync.py` também aproveita as chaves configuradas em `SUBNET_ID_MAP_JSON` (ou equivalentes) para buscar as sub-redes no phpIPAM e cruza cada IP com os dados de `$config['interfaces']`. Dessa forma ele descobre automaticamente qual interface DHCP deve receber as reservas, eliminando a necessidade de mapear `lan`, `vlanX` etc. manualmente.
 

--- a/json_kea_ipam_sync.py
+++ b/json_kea_ipam_sync.py
@@ -785,6 +785,23 @@ def ipam_get_addresses(
     return (0, rows)
 
 
+def ipam_get_subnet(
+    base: str,
+    token: str,
+    subnet_id: str,
+    verify_tls: bool,
+) -> Tuple[int, Optional[Dict[str, Any]]]:
+    url = f"{base}/api/{env_first('PHPIPAM_APP_ID', 'IPAM_APP_ID', default='kea')}/subnets/{subnet_id}/"
+    rc, data = ipam_request("GET", url, token=token, verify_tls=verify_tls)
+    if rc != 0 or not data:
+        return (1, None)
+    subnet = data.get("data")
+    if not isinstance(subnet, dict):
+        _err(f"phpIPAM retornou dados inesperados ao consultar a sub-rede {subnet_id}")
+        return (1, None)
+    return (0, subnet)
+
+
 def pick_first(row: Dict[str, Any], keys: List[str], default: Any = None) -> Any:
     for key in keys:
         if key in row:

--- a/pfsense_kea_ipam_sync.py
+++ b/pfsense_kea_ipam_sync.py
@@ -268,13 +268,20 @@ def push_pfsense_config(
 
 
 def get_config_path_segments() -> List[str]:
-    raw = jk.env_first("PF_CONFIG_PATH", "PFSENSE_CONFIG_PATH")
     default_path = "dhcpd"
+    raw = jk.env_first("PF_CONFIG_PATH", "PFSENSE_CONFIG_PATH")
+    if raw:
+        raw = raw.strip()
     if not raw:
-        raw = default_path
+        return [default_path]
     segments = [segment.strip() for segment in raw.split(":") if segment.strip()]
     if not segments:
         raise ValueError("PF_CONFIG_PATH vazio")
+    if segments != [default_path]:
+        jk._warn(
+            "PF_CONFIG_PATH diferente de 'dhcpd' foi ignorado — o modo pfSense sempre escreve em $config['dhcpd']"
+        )
+        return [default_path]
     return segments
 
 


### PR DESCRIPTION
## Summary
- replace the previous Kea package writer with logic that reads and writes $config['dhcpd'] so phpIPAM reservations become native static-maps
- add helpers to parse subnet-to-interface mappings, convert phpIPAM rows into pfSense static-map entries, and reload the DHCP service after write_config
- update the CLI messaging and safeguards so the script refuses to overwrite dhcpd when it cannot read the current configuration

## Testing
- python3 -m py_compile pfsense_kea_ipam_sync.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b381be20483278641037c3506ca14)