### PR TITLE
Handle empty subnets and guard pfSense config state

### DIFF
--- a/json_kea_ipam_sync.py
+++ b/json_kea_ipam_sync.py
@@ -47,6 +47,13 @@ _DEBUG_ENV_NAMES = (
     "KEA_IPAM_SYNC_DEBUG",
     "PFSENSE_IPAM_SYNC_DEBUG",
 )
+_DEBUG_ONE_BY_ONE_ENV_NAMES = (
+    "DEBUG_ONE_A_ONE",
+    "DEBUG_ONE_BY_ONE",
+    "PFSENSE_DEBUG_ONE_A_ONE",
+    "PFSENSE_DEBUG_ONE_BY_ONE",
+    "KEA_IPAM_SYNC_DEBUG_ONE_A_ONE",
+)
 _DEBUG_TRUE_VALUES = {"1", "true", "yes", "y", "sim", "on"}
 _DEBUG_FALSE_VALUES = {"0", "false", "no", "n", "nao", "off"}
 
@@ -176,6 +183,19 @@ def _debug(msg: str) -> None:
 
 def is_debug_enabled() -> bool:
     return _is_debug_enabled()
+
+
+def is_debug_one_by_one_enabled() -> bool:
+    for name in _DEBUG_ONE_BY_ONE_ENV_NAMES:
+        value = os.getenv(name)
+        if value is None:
+            continue
+        s = str(value).strip().lower()
+        if s in _DEBUG_TRUE_VALUES:
+            return True
+        if s in _DEBUG_FALSE_VALUES:
+            return False
+    return False
 
 
 def _info(msg: str) -> None:

--- a/json_kea_ipam_sync.py
+++ b/json_kea_ipam_sync.py
@@ -42,6 +42,13 @@ _LOGGER.propagate = False
 _LOGGER_INITIALIZED = False
 _CURRENT_LOG_DIR: Optional[str] = None
 _CURRENT_RETENTION_DAYS = DEFAULT_LOG_RETENTION_DAYS
+_DEBUG_ENV_NAMES = (
+    "DEBUG",
+    "KEA_IPAM_SYNC_DEBUG",
+    "PFSENSE_IPAM_SYNC_DEBUG",
+)
+_DEBUG_TRUE_VALUES = {"1", "true", "yes", "y", "sim", "on"}
+_DEBUG_FALSE_VALUES = {"0", "false", "no", "n", "nao", "off"}
 
 
 def _cleanup_old_logs(log_dir: str, keep_days: int) -> None:
@@ -144,14 +151,31 @@ def _ensure_logger() -> logging.Logger:
     return _LOGGER
 
 
+def _is_debug_enabled() -> bool:
+    for name in _DEBUG_ENV_NAMES:
+        value = os.getenv(name)
+        if value is None:
+            continue
+        s = str(value).strip().lower()
+        if s in _DEBUG_TRUE_VALUES:
+            return True
+        if s in _DEBUG_FALSE_VALUES:
+            return False
+    return False
+
+
 def _log(level: int, message: str) -> None:
     logger = _ensure_logger()
     logger.log(level, message)
 
 
 def _debug(msg: str) -> None:
-    if os.getenv("DEBUG", "false").lower() in ("1", "true", "yes", "on"):
+    if _is_debug_enabled():
         _log(logging.DEBUG, f"[DEBUG] {msg}")
+
+
+def is_debug_enabled() -> bool:
+    return _is_debug_enabled()
 
 
 def _info(msg: str) -> None:

--- a/pfsense_kea_ipam_sync.py
+++ b/pfsense_kea_ipam_sync.py
@@ -82,6 +82,11 @@ def _php_apply_staticmaps_code(payload_b64: str, note_b64: str) -> str:
         @require_once('/etc/inc/functions.inc');
         @require_once('/etc/inc/services.inc');
 
+        if (isset($config) == false || is_array($config) == false) {
+            echo base64_encode(json_encode(['ok'=>false,'error'=>'config.xml inválido ou não carregado']));
+            exit(1);
+        }
+
         function normalize_staticmap_entry($entry) {{
             if (is_array($entry) == false) {{
                 return null;
@@ -708,9 +713,13 @@ def sync(dry_run: bool = False, delete_missing: bool = True) -> Tuple[int, int, 
             str(ipam_subnet), items, iface_networks, base, token, verify_tls, subnet_network_cache
         )
         if not iface:
-            jk._err(
+            base_msg = (
                 f"Não foi possível associar a sub-rede {ipam_subnet} a nenhuma interface do pfSense; confira o config.xml e as VLANs."
             )
+            if not items:
+                jk._warn(base_msg + " — sub-rede sem IPs foi ignorada")
+                continue
+            jk._err(base_msg)
             errors += 1
             continue
 

--- a/pfsense_kea_ipam_sync.py
+++ b/pfsense_kea_ipam_sync.py
@@ -12,6 +12,7 @@ import shlex
 import subprocess
 import sys
 import time
+import unicodedata
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 import json_kea_ipam_sync as jk
@@ -32,7 +33,9 @@ def _compact_php(code: str) -> str:
 
 
 def _sanitize_hostname(hostname: str, max_length: int = 63) -> str:
-    cleaned = "".join(ch for ch in hostname if ch.isalnum() or ch in "-._")
+    normalized = unicodedata.normalize("NFKD", hostname)
+    normalized = "".join(ch for ch in normalized if unicodedata.category(ch) != "Mn")
+    cleaned = "".join(ch for ch in normalized if ch.isalnum() or ch in "-._")
     cleaned = cleaned.strip("-._")
     if len(cleaned) > max_length:
         cleaned = cleaned[:max_length]

--- a/pfsense_kea_ipam_sync.py
+++ b/pfsense_kea_ipam_sync.py
@@ -82,10 +82,10 @@ def _php_apply_staticmaps_code(payload_b64: str, note_b64: str) -> str:
         @require_once('/etc/inc/functions.inc');
         @require_once('/etc/inc/services.inc');
 
-        if (isset($config) == false || is_array($config) == false) {
+        if (isset($config) == false || is_array($config) == false) {{
             echo base64_encode(json_encode(['ok'=>false,'error'=>'config.xml inválido ou não carregado']));
             exit(1);
-        }
+        }}
 
         function normalize_staticmap_entry($entry) {{
             if (is_array($entry) == false) {{


### PR DESCRIPTION
## Summary
- add explicit check for invalid pfSense configuration objects before applying changes
- avoid treating phpIPAM subnets without addresses as hard errors during sync

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926f0753c0483278877c4b5ffd4e97b)